### PR TITLE
Fix Repository Name in Travis Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Analyze your docker images, without running them!
 
 # Build #
-[![Build Status](https://travis-ci.org/blackducksoftware/hub-docker.svg?branch=master)](https://travis-ci.org/blackducksoftware/hub-docker)
+[![Build Status](https://travis-ci.org/blackducksoftware/hub-docker-inspector.svg?branch=master)](https://travis-ci.org/blackducksoftware/hub-docker-inspector)
 [![Black Duck Security Risk](https://copilot.blackducksoftware.com/github/groups/blackducksoftware/locations/hub-docker/public/results/branches/master/badge-risk.svg)](https://copilot.blackducksoftware.com/github/groups/blackducksoftware/locations/hub-docker/public/results/branches/master)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 


### PR DESCRIPTION
The repository name was (still?) hub-docker in the travis badge URLs, resulting in an invalid badge. Updated to hub-docker-inspector